### PR TITLE
feat(hal/cortex_m): add DataWatchpointAndTrace

### DIFF
--- a/hal/cortex_m/CMakeLists.txt
+++ b/hal/cortex_m/CMakeLists.txt
@@ -8,6 +8,8 @@ target_include_directories(hal.cortex_m PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>")
 
 target_sources(hal.cortex_m PRIVATE
+    DataWatchpointAndTrace.hpp
+    DataWatchpointAndTrace.cpp
     FaultTracer.hpp
     FaultTracer.cpp
     InterruptCortex.hpp

--- a/hal/cortex_m/DataWatchpointAndTrace.cpp
+++ b/hal/cortex_m/DataWatchpointAndTrace.cpp
@@ -1,0 +1,47 @@
+#include "hal/cortex_m/DataWatchpointAndTrace.hpp"
+
+#if !defined(__ARM_ARCH_6M__)
+
+namespace
+{
+    constexpr uintptr_t demcrAddr = 0xE000EDFCu;
+    constexpr uint32_t demcrTrcena = 1u << 24;
+
+    constexpr uintptr_t dwtCtrlAddr = 0xE0001000u;
+    constexpr uintptr_t dwtCyccntAddr = 0xE0001004u;
+    constexpr uint32_t dwtCtrlCyccntena = 1u << 0;
+
+    volatile uint32_t& Reg32(uintptr_t address)
+    {
+        return *reinterpret_cast<volatile uint32_t*>(address);
+    }
+}
+
+namespace hal::cortex
+{
+    DataWatchpointAndTrace::DataWatchpointAndTrace()
+    {
+        Reg32(demcrAddr) |= demcrTrcena;
+        Reg32(dwtCyccntAddr) = 0;
+    }
+
+    DataWatchpointAndTrace::~DataWatchpointAndTrace()
+    {
+        Reg32(demcrAddr) &= ~demcrTrcena;
+    }
+
+    void DataWatchpointAndTrace::Start() const
+    {
+        Reg32(dwtCyccntAddr) = 0;
+        Reg32(dwtCtrlAddr) |= dwtCtrlCyccntena;
+    }
+
+    uint32_t DataWatchpointAndTrace::Stop() const
+    {
+        uint32_t cycles = Reg32(dwtCyccntAddr);
+        Reg32(dwtCtrlAddr) &= ~dwtCtrlCyccntena;
+        return cycles;
+    }
+}
+
+#endif

--- a/hal/cortex_m/DataWatchpointAndTrace.hpp
+++ b/hal/cortex_m/DataWatchpointAndTrace.hpp
@@ -1,0 +1,25 @@
+#ifndef HAL_CORTEX_M_DATA_WATCHPOINT_AND_TRACE_HPP
+#define HAL_CORTEX_M_DATA_WATCHPOINT_AND_TRACE_HPP
+
+#include "infra/util/InterfaceConnector.hpp"
+#include <cstdint>
+
+#if !defined(__ARM_ARCH_6M__)
+
+namespace hal::cortex
+{
+    class DataWatchpointAndTrace
+        : public infra::InterfaceConnector<DataWatchpointAndTrace>
+    {
+    public:
+        DataWatchpointAndTrace();
+        ~DataWatchpointAndTrace();
+
+        void Start() const;
+        uint32_t Stop() const;
+    };
+}
+
+#endif
+
+#endif


### PR DESCRIPTION
## Summary
- Adds `hal::cortex::DataWatchpointAndTrace`, wrapping the DWT cycle counter (CYCCNT) for measuring elapsed cycles around a span of code — the last piece of hal-st's old `hal_st/cortex/` that had no home in `hal/cortex_m` yet.
- Same style as `InterruptCortex`/`FaultTracer`: fixed register addresses, no CMSIS device header dependency.
- Compiles out entirely on ARMv6-M (DWT isn't implemented there), matching how `FaultTracer` already skips the status-register reads ARMv6-M lacks.
- Fixes a latent bug found while porting: the code this replaces toggled `DWT_CTRL_CYCEVTENA` (bit 22, POSTCNT underflow event enable) instead of `DWT_CTRL_CYCCNTENA` (bit 0, the actual cycle-counter enable) — verified against the real CMSIS `core_cm4.h` bit definitions.

Closes #96

## Test plan
- [x] Compiled `DataWatchpointAndTrace.cpp` directly with `arm-none-eabi-g++` (cortex-m4, hard-float) against this branch's `infra/util/InterfaceConnector.hpp` — clean build, correct symbols
- [ ] No automated test added: DWT's cycle-counting behavior isn't meaningfully verifiable on host or (as far as I could tell) in the existing qemu test harness; happy to add one if there's a preferred pattern for this
- [ ] hal-st side: swap its own `hal_st/dwt/DataWatchpointAndTrace` for this once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)