### PR TITLE
feat: add LowPriorityInterrupt and DataWatchpointAndTrace

### DIFF
--- a/hal/cortex_m/CMakeLists.txt
+++ b/hal/cortex_m/CMakeLists.txt
@@ -8,10 +8,14 @@ target_include_directories(hal.cortex_m PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>")
 
 target_sources(hal.cortex_m PRIVATE
+    DataWatchpointAndTrace.hpp
+    DataWatchpointAndTrace.cpp
     FaultTracer.hpp
     FaultTracer.cpp
     InterruptCortex.hpp
-    InterruptCortex.cpp)
+    InterruptCortex.cpp
+    LowPriorityInterrupt.hpp
+    LowPriorityInterrupt.cpp)
 
 target_link_libraries(hal.cortex_m PUBLIC
     hal.cortex_m.runtime

--- a/hal/cortex_m/DataWatchpointAndTrace.cpp
+++ b/hal/cortex_m/DataWatchpointAndTrace.cpp
@@ -1,0 +1,41 @@
+#include "hal/cortex_m/DataWatchpointAndTrace.hpp"
+
+namespace
+{
+    constexpr uintptr_t coreDebugDemcr = 0xE000EDFCu;
+    constexpr uint32_t demcrTrcena = 1u << 24;
+
+    constexpr uintptr_t dwtCtrl = 0xE0001000u;
+    constexpr uint32_t dwtCyccntena = 1u << 0;
+
+    constexpr uintptr_t dwtCyccnt = 0xE0001004u;
+
+    volatile uint32_t& Reg32(uintptr_t address)
+    {
+        return *reinterpret_cast<volatile uint32_t*>(address);
+    }
+}
+
+namespace hal::cortex
+{
+    DataWatchpointAndTrace::DataWatchpointAndTrace()
+    {
+        Reg32(coreDebugDemcr) |= demcrTrcena;
+    }
+
+    void DataWatchpointAndTrace::Start()
+    {
+        Reg32(dwtCyccnt) = 0;
+        Reg32(dwtCtrl) |= dwtCyccntena;
+    }
+
+    void DataWatchpointAndTrace::Stop()
+    {
+        Reg32(dwtCtrl) &= ~dwtCyccntena;
+    }
+
+    uint32_t DataWatchpointAndTrace::Cycles() const
+    {
+        return Reg32(dwtCyccnt);
+    }
+}

--- a/hal/cortex_m/DataWatchpointAndTrace.hpp
+++ b/hal/cortex_m/DataWatchpointAndTrace.hpp
@@ -1,0 +1,19 @@
+#ifndef HAL_CORTEX_M_DATA_WATCHPOINT_AND_TRACE_HPP
+#define HAL_CORTEX_M_DATA_WATCHPOINT_AND_TRACE_HPP
+
+#include <cstdint>
+
+namespace hal::cortex
+{
+    class DataWatchpointAndTrace
+    {
+    public:
+        DataWatchpointAndTrace();
+
+        void Start();
+        void Stop();
+        uint32_t Cycles() const;
+    };
+}
+
+#endif

--- a/hal/cortex_m/InterruptCortex.cpp
+++ b/hal/cortex_m/InterruptCortex.cpp
@@ -21,6 +21,9 @@ namespace
     constexpr uintptr_t scbIcsr = 0xE000ED04u;
     constexpr uint32_t scbIcsrVectactiveMsk = 0x1FFu;
     constexpr uint32_t scbIcsrPendstclr = 1u << 25;
+    constexpr uint32_t scbIcsrPendSvSet = 1u << 28;
+    constexpr uint32_t scbIcsrPendSvClr = 1u << 27;
+    constexpr uintptr_t scbShpr3PendSv = 0xE000ED22u;
 
     constexpr uintptr_t systCsr = 0xE000E010u;
     constexpr uint32_t systTickint = 1u << 1;
@@ -28,6 +31,11 @@ namespace
     volatile uint32_t& Reg32(uintptr_t address)
     {
         return *reinterpret_cast<volatile uint32_t*>(address);
+    }
+
+    volatile uint8_t& Reg8(uintptr_t address)
+    {
+        return *reinterpret_cast<volatile uint8_t*>(address);
     }
 
     void Dmb()
@@ -84,6 +92,11 @@ namespace
         }
         else if (irq == hal::cortex::sysTickIrq)
             Reg32(systCsr) |= systTickint;
+        else if (irq == hal::cortex::pendSvIrq)
+        {
+            Reg8(scbShpr3PendSv) = PriorityByte(priority);
+            Dsb();
+        }
     }
 
     void DisableIrq(int32_t irq)
@@ -98,6 +111,8 @@ namespace
             Reg32(systCsr) &= ~systTickint;
             Reg32(scbIcsr) = scbIcsrPendstclr;
         }
+        else if (irq == hal::cortex::pendSvIrq)
+            Reg32(scbIcsr) = scbIcsrPendSvClr;
     }
 
     void ClearPendingIrq(int32_t irq)
@@ -106,6 +121,8 @@ namespace
             IrqBitBand(nvicIcpr0, irq) = IrqBit(irq);
         else if (irq == hal::cortex::sysTickIrq)
             Reg32(scbIcsr) = scbIcsrPendstclr;
+        else if (irq == hal::cortex::pendSvIrq)
+            Reg32(scbIcsr) = scbIcsrPendSvClr;
     }
 }
 

--- a/hal/cortex_m/LowPriorityInterrupt.cpp
+++ b/hal/cortex_m/LowPriorityInterrupt.cpp
@@ -13,6 +13,11 @@ namespace
 
 namespace hal::cortex
 {
+    LowPriorityInterrupt::LowPriorityInterrupt()
+        : onInvoke{ []() {} }
+    {
+    }
+
     void LowPriorityInterrupt::Trigger()
     {
         Reg32(scbIcsr) = scbIcsrPendSvSet;
@@ -27,12 +32,11 @@ namespace hal::cortex
     void LowPriorityInterrupt::Unregister()
     {
         InterruptHandler::Unregister();
-        onInvoke = nullptr;
+        onInvoke = []() {};
     }
 
     void LowPriorityInterrupt::Invoke()
     {
-        if (onInvoke)
-            onInvoke();
+        onInvoke();
     }
 }

--- a/hal/cortex_m/LowPriorityInterrupt.cpp
+++ b/hal/cortex_m/LowPriorityInterrupt.cpp
@@ -1,0 +1,38 @@
+#include "hal/cortex_m/LowPriorityInterrupt.hpp"
+
+namespace
+{
+    constexpr uintptr_t scbIcsr = 0xE000ED04u;
+    constexpr uint32_t scbIcsrPendSvSet = 1u << 28;
+
+    volatile uint32_t& Reg32(uintptr_t address)
+    {
+        return *reinterpret_cast<volatile uint32_t*>(address);
+    }
+}
+
+namespace hal::cortex
+{
+    void LowPriorityInterrupt::Trigger()
+    {
+        Reg32(scbIcsr) = scbIcsrPendSvSet;
+    }
+
+    void LowPriorityInterrupt::Register(const infra::Function<void()>& handler)
+    {
+        onInvoke = handler;
+        InterruptHandler::Register(pendSvIrq, InterruptPriority::lowest);
+    }
+
+    void LowPriorityInterrupt::Unregister()
+    {
+        InterruptHandler::Unregister();
+        onInvoke = nullptr;
+    }
+
+    void LowPriorityInterrupt::Invoke()
+    {
+        if (onInvoke)
+            onInvoke();
+    }
+}

--- a/hal/cortex_m/LowPriorityInterrupt.cpp
+++ b/hal/cortex_m/LowPriorityInterrupt.cpp
@@ -13,11 +13,6 @@ namespace
 
 namespace hal::cortex
 {
-    LowPriorityInterrupt::LowPriorityInterrupt()
-        : onInvoke{ []() {} }
-    {
-    }
-
     void LowPriorityInterrupt::Trigger()
     {
         Reg32(scbIcsr) = scbIcsrPendSvSet;

--- a/hal/cortex_m/LowPriorityInterrupt.hpp
+++ b/hal/cortex_m/LowPriorityInterrupt.hpp
@@ -1,0 +1,25 @@
+#ifndef HAL_CORTEX_M_LOW_PRIORITY_INTERRUPT_HPP
+#define HAL_CORTEX_M_LOW_PRIORITY_INTERRUPT_HPP
+
+#include "hal/cortex_m/InterruptCortex.hpp"
+#include "infra/util/Function.hpp"
+
+namespace hal::cortex
+{
+    class LowPriorityInterrupt
+        : private InterruptHandler
+    {
+    public:
+        void Trigger();
+        void Register(const infra::Function<void()>& handler);
+        void Unregister();
+
+    private:
+        void Invoke() override;
+
+    private:
+        infra::Function<void()> onInvoke;
+    };
+}
+
+#endif

--- a/hal/cortex_m/LowPriorityInterrupt.hpp
+++ b/hal/cortex_m/LowPriorityInterrupt.hpp
@@ -3,15 +3,15 @@
 
 #include "hal/cortex_m/InterruptCortex.hpp"
 #include "infra/util/Function.hpp"
+#include "infra/util/InterfaceConnector.hpp"
 
 namespace hal::cortex
 {
     class LowPriorityInterrupt
-        : private InterruptHandler
+        : public infra::InterfaceConnector<LowPriorityInterrupt>
+        , private InterruptHandler
     {
     public:
-        LowPriorityInterrupt();
-
         void Trigger();
         void Register(const infra::Function<void()>& handler);
         void Unregister();
@@ -20,7 +20,7 @@ namespace hal::cortex
         void Invoke() override;
 
     private:
-        infra::Function<void()> onInvoke;
+        infra::Function<void()> onInvoke{ []() {} };
     };
 }
 

--- a/hal/cortex_m/LowPriorityInterrupt.hpp
+++ b/hal/cortex_m/LowPriorityInterrupt.hpp
@@ -10,6 +10,8 @@ namespace hal::cortex
         : private InterruptHandler
     {
     public:
+        LowPriorityInterrupt();
+
         void Trigger();
         void Register(const infra::Function<void()>& handler);
         void Unregister();

--- a/hal/qemu/test/CMakeLists.txt
+++ b/hal/qemu/test/CMakeLists.txt
@@ -4,8 +4,10 @@ emil_build_for(hal.qemu.test
     BOOL EMIL_BUILD_QEMU)
 
 target_sources(hal.qemu.test PRIVATE
+    TestDataWatchpointAndTrace.cpp
     TestFaultTracer.cpp
     TestInterruptCortex.cpp
+    TestLowPriorityInterrupt.cpp
     TestSemihostingWriter.cpp
     TestSystemTickTimerService.cpp)
 

--- a/hal/qemu/test/TestDataWatchpointAndTrace.cpp
+++ b/hal/qemu/test/TestDataWatchpointAndTrace.cpp
@@ -1,0 +1,20 @@
+#include "hal/cortex_m/DataWatchpointAndTrace.hpp"
+#include "gtest/gtest.h"
+
+TEST(DataWatchpointAndTraceTest, cycles_are_zero_after_start)
+{
+    hal::cortex::DataWatchpointAndTrace dwt;
+    dwt.Start();
+
+    EXPECT_EQ(0u, dwt.Cycles());
+}
+
+TEST(DataWatchpointAndTraceTest, cycles_are_zero_after_second_start)
+{
+    hal::cortex::DataWatchpointAndTrace dwt;
+    dwt.Start();
+    dwt.Stop();
+    dwt.Start();
+
+    EXPECT_EQ(0u, dwt.Cycles());
+}

--- a/hal/qemu/test/TestLowPriorityInterrupt.cpp
+++ b/hal/qemu/test/TestLowPriorityInterrupt.cpp
@@ -1,0 +1,54 @@
+#include "hal/cortex_m/LowPriorityInterrupt.hpp"
+#include "infra/event/test_helper/EventDispatcherFixture.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+class LowPriorityInterruptTest
+    : public testing::Test
+    , public infra::EventDispatcherFixture
+{
+public:
+    hal::cortex::InterruptTable::WithStorage<64> interruptTable;
+    hal::cortex::LowPriorityInterrupt lpi;
+};
+
+TEST_F(LowPriorityInterruptTest, register_stores_handler_in_table)
+{
+    lpi.Register([]() {});
+
+    EXPECT_NE(nullptr, interruptTable.Handler(hal::cortex::pendSvIrq));
+}
+
+TEST_F(LowPriorityInterruptTest, invoke_calls_registered_callback)
+{
+    bool called{ false };
+    lpi.Register([&called]()
+        {
+            called = true;
+        });
+
+    interruptTable.Invoke(hal::cortex::pendSvIrq);
+
+    EXPECT_TRUE(called);
+}
+
+TEST_F(LowPriorityInterruptTest, unregister_clears_the_slot)
+{
+    lpi.Register([]() {});
+    lpi.Unregister();
+
+    EXPECT_EQ(nullptr, interruptTable.Handler(hal::cortex::pendSvIrq));
+}
+
+TEST_F(LowPriorityInterruptTest, invoke_does_not_call_callback_after_unregister)
+{
+    bool called{ false };
+    lpi.Register([&called]()
+        {
+            called = true;
+        });
+    lpi.Unregister();
+
+    EXPECT_EQ(nullptr, interruptTable.Handler(hal::cortex::pendSvIrq));
+    EXPECT_FALSE(called);
+}


### PR DESCRIPTION
Closes #97 — PendSV-based LowPriorityInterrupt with Trigger/Register/ Unregister built on the existing InterruptHandler/InterruptTable machinery. Extends EnableIrq/DisableIrq/ClearPendingIrq in InterruptCortex to handle pendSvIrq via SCB SHPR3 priority and ICSR PENDSVCLR.

Closes #96 — DataWatchpointAndTrace cycle counter using fixed DWT/CoreDebug register addresses (no CMSIS headers), matching the existing pattern.